### PR TITLE
:bug: use logical property mixin when logical property is true

### DIFF
--- a/scss/tools/mixins/_fluid-property.scss
+++ b/scss/tools/mixins/_fluid-property.scss
@@ -12,7 +12,7 @@
 
   @if $illusion-logical-properties {
     @if $u1 == $u2 and $u3 == $u4 {
-      #{$property}: clamp(#{$min-value}, calc(#{$min-value} + #{strip-unit($max-value - $min-value)} * ((100vw - #{$min-screen}) / #{strip-unit($max-screen - $min-screen)} * #{math.div($max-screen, $min-screen)})), #{$max-value});
+      @include property("#{$property}", clamp(#{$min-value}, calc(#{$min-value} + #{strip-unit($max-value - $min-value)} * ((100vw - #{$min-screen}) / #{strip-unit($max-screen - $min-screen)} * #{math.div($max-screen, $min-screen)})), #{$max-value}));
     }
   } @else {
     @if $u1 == $u2 and $u3 == $u4 {

--- a/scss/tools/mixins/_modular-scale.scss
+++ b/scss/tools/mixins/_modular-scale.scss
@@ -22,9 +22,9 @@
   // Logical properties?
   @if $illusion-logical-properties {
     @if ($subtractFrom) {
-      #{$property}: calc(#{$subtractFrom} - (var(--spacing) * #{$ms-amount}));
+      @include property("#{$property}", calc(#{$subtractFrom} - (var(--spacing) * #{$ms-amount})));
     } @else {
-      #{$property}: calc(var(--spacing) * #{$ms-amount});
+      @include property("#{$property}", calc(var(--spacing) * #{$ms-amount}));
     }
   } @else {
     // Default


### PR DESCRIPTION
When variable $illusion-logical-properties is true, the mixin modular-scale should use $illusion-logical-properties-map my calling mixin property