### PR TITLE
Mixin vars on separate rows

### DIFF
--- a/scss/tools/mixins/_breakpoint.scss
+++ b/scss/tools/mixins/_breakpoint.scss
@@ -1,7 +1,11 @@
 // Breakpoint
 // Sets a temporary global $inside-breakpoint variable to be used inside other mixins
 
-@mixin breakpoint($width, $width--max: $illusion-breakpoint-width-max, $type: $illusion-breakpoint-type) {
+@mixin breakpoint(
+  $width,
+  $width--max: $illusion-breakpoint-width-max,
+  $type: $illusion-breakpoint-type
+) {
   $inside-breakpoint: $width !global;
   $bp-width: if($type == inherit, $width, #{strip-unit($width)}#{$illusion-breakpoint-type});
   $bp-width--max: if($type == inherit, $width--max, #{strip-unit($width--max)}#{$illusion-breakpoint-type});

--- a/scss/tools/mixins/_button.scss
+++ b/scss/tools/mixins/_button.scss
@@ -7,7 +7,12 @@
 // 3. Line buttons vertically
 // 4. Appear clickable
 
-@mixin button-structure($appearance: $illusion-button-appearance, $display: $illusion-button-display, $vertical-align: $illusion-button-vertical-align, $cursor: $illusion-button-cursor) {
+@mixin button-structure(
+  $appearance: $illusion-button-appearance,
+  $display: $illusion-button-display,
+  $vertical-align: $illusion-button-vertical-align,
+  $cursor: $illusion-button-cursor
+) {
   @if $appearance != false {
     -webkit-appearance: $appearance; // 1
   }

--- a/scss/tools/mixins/_clearfix.scss
+++ b/scss/tools/mixins/_clearfix.scss
@@ -2,7 +2,9 @@
 // Also clearing top-margin
 // Still using single colon for better browser compatibility
 
-@mixin clearfix($reset: $illusion-clearfix-reset) {
+@mixin clearfix(
+  $reset: $illusion-clearfix-reset
+) {
   @if $reset == false {
     &::before,
     &::after {

--- a/scss/tools/mixins/_cluster.scss
+++ b/scss/tools/mixins/_cluster.scss
@@ -1,6 +1,11 @@
 // Cluster
 
-@mixin cluster($margin: $illusion-cluster-margin, $flex-wrap: $illusion-cluster-flex-wrap, $align-items: $illusion-cluster-align-items, $justify-content: $illusion-cluster-justify-content) {
+@mixin cluster(
+  $margin: $illusion-cluster-margin,
+  $flex-wrap: $illusion-cluster-flex-wrap,
+  $align-items: $illusion-cluster-align-items,
+  $justify-content: $illusion-cluster-justify-content
+) {
   @if $illusion-logical-properties {
     display: flex;
     flex-wrap: wrap;

--- a/scss/tools/mixins/_collapse.scss
+++ b/scss/tools/mixins/_collapse.scss
@@ -3,7 +3,12 @@
 // Use as direct child of `@include span` element
 // Make sure there's no padding on the parent element
 
-@mixin collapse($sides: $illusion-collapse-sides, $multiplier: $illusion-collapse-multiplier, $fromto: $illusion-collapse-fromto, $gutter: $illusion-collapse-gutter) {
+@mixin collapse(
+  $sides: $illusion-collapse-sides,
+  $multiplier: $illusion-collapse-multiplier,
+  $fromto: $illusion-collapse-fromto,
+  $gutter: $illusion-collapse-gutter
+) {
 
   // Give a warning when $multiplier is not dividable by 0.5
   @if ($multiplier % 0.5 != 0 and $illusion-display-warnings != false) {

--- a/scss/tools/mixins/_container.scss
+++ b/scss/tools/mixins/_container.scss
@@ -1,6 +1,9 @@
 // Container
 
-@mixin container($type: $illusion-grid-container-type, $align: $illusion-grid-container-align) {
+@mixin container(
+  $type: $illusion-grid-container-type,
+  $align: $illusion-grid-container-align
+) {
 
   // Set default styling
   @include property("max-width", $illusion-grid-maxwidth + (largestGutter() * 2));

--- a/scss/tools/mixins/_content-block.scss
+++ b/scss/tools/mixins/_content-block.scss
@@ -1,6 +1,9 @@
 // Content block
 
-@mixin content-block($spacing: $illusion-content-block-spacing, $location: $illusion-content-block-location ) {
+@mixin content-block(
+  $spacing: $illusion-content-block-spacing,
+  $location: $illusion-content-block-location
+) {
   @if $location == top {
     @include property("margin-top", $spacing);
 

--- a/scss/tools/mixins/_coverall.scss
+++ b/scss/tools/mixins/_coverall.scss
@@ -1,6 +1,14 @@
 // Cover the entire parent element
 
-@mixin coverall($offset: $illusion-coverall-offset, $top: $illusion-coverall-top, $right: $illusion-coverall-right, $bottom: $illusion-coverall-bottom, $left: $illusion-coverall-left, $position: $illusion-coverall-position, $reset: $illusion-coverall-reset) {
+@mixin coverall(
+  $offset: $illusion-coverall-offset,
+  $top: $illusion-coverall-top,
+  $right: $illusion-coverall-right,
+  $bottom: $illusion-coverall-bottom,
+  $left: $illusion-coverall-left,
+  $position: $illusion-coverall-position,
+  $reset: $illusion-coverall-reset
+) {
   @if $position != false {
     position: $position;
   }

--- a/scss/tools/mixins/_flexbox.scss
+++ b/scss/tools/mixins/_flexbox.scss
@@ -8,7 +8,10 @@
 // Because we're adding .flexbox and .flexboxlegacy classes flexbox will only work when JS is enabled
 // This is a good thing since we're not sure what we're showing / hiding with JS that might mess with flexbox
 
-@mixin flexbox($horizontal: $illusion-flexbox-horizontal, $vertical: $illusion-flexbox-vertical) {
+@mixin flexbox(
+  $horizontal: $illusion-flexbox-horizontal,
+  $vertical: $illusion-flexbox-vertical
+) {
   @if $illusion-flexbox == true { // 1
     @at-root { // 2
       .flexbox &, // 3

--- a/scss/tools/mixins/_fluid-property.scss
+++ b/scss/tools/mixins/_fluid-property.scss
@@ -2,7 +2,13 @@
 
 @use "sass:math";
 
-@mixin fluid-property($property, $min-value: $illusion-fluid-property-min-value, $max-value: $illusion-fluid-property-max-value, $min-screen: $illusion-fluid-property-min-screen, $max-screen: $illusion-fluid-property-max-screen) {
+@mixin fluid-property(
+  $property,
+  $min-value: $illusion-fluid-property-min-value,
+  $max-value: $illusion-fluid-property-max-value,
+  $min-screen: $illusion-fluid-property-min-screen,
+  $max-screen: $illusion-fluid-property-max-screen
+) {
 
   // Variables
   $u1: unit($min-screen);

--- a/scss/tools/mixins/_gallery.scss
+++ b/scss/tools/mixins/_gallery.scss
@@ -2,7 +2,16 @@
 
 @use "sass:math";
 
-@mixin gallery($span: $illusion-gallery-span, $fromto: $illusion-gallery-fromto, $multiplier: $illusion-gallery-multiplier, $bottom: $illusion-gallery-bottom, $defaults: $illusion-gallery-defaults, $gutter: $illusion-gallery-gutter, $includeWidth: $illusion-gallery-includeWidth, $includeMargin: $illusion-gallery-includeMargin) {
+@mixin gallery(
+  $span: $illusion-gallery-span,
+  $fromto: $illusion-gallery-fromto,
+  $multiplier: $illusion-gallery-multiplier,
+  $bottom: $illusion-gallery-bottom,
+  $defaults: $illusion-gallery-defaults,
+  $gutter: $illusion-gallery-gutter,
+  $includeWidth: $illusion-gallery-includeWidth,
+  $includeMargin: $illusion-gallery-includeMargin
+) {
 
   // Span values
   $spanColumns: nth($span, 1);

--- a/scss/tools/mixins/_hover.scss
+++ b/scss/tools/mixins/_hover.scss
@@ -1,7 +1,9 @@
 // Hover mixin
 // Sets styling for both hover and focus
 
-@mixin hover($focusWithin: $illusion-hover-focusWithin) {
+@mixin hover(
+  $focusWithin: $illusion-hover-focusWithin
+) {
   @if ($focusWithin != false) {
     &:hover,
     &:focus,

--- a/scss/tools/mixins/_ifBreakpoint.scss
+++ b/scss/tools/mixins/_ifBreakpoint.scss
@@ -1,6 +1,8 @@
 // Do or don't use breakpoint depending on width
 
-@mixin ifBreakpoint($width) {
+@mixin ifBreakpoint(
+  $width
+) {
 
   // Don't use media query when width = 0
   @if $width == 0 {

--- a/scss/tools/mixins/_modernizr.scss
+++ b/scss/tools/mixins/_modernizr.scss
@@ -12,7 +12,9 @@
 //   display: flex;
 // }
 
-@mixin modernizr($classes...) {
+@mixin modernizr(
+  $classes...
+) {
   @at-root {
 
     // Create new classlist variable

--- a/scss/tools/mixins/_modular-scale.scss
+++ b/scss/tools/mixins/_modular-scale.scss
@@ -3,7 +3,12 @@
 // Responsive spacing items apart with an old browser fallback
 // This is a responsive spacer
 
-@mixin ms($property, $amount: 0, $multiplier: 1, $subtractFrom: false) {
+@mixin ms(
+  $property,
+  $amount: 0,
+  $multiplier: 1,
+  $subtractFrom: false
+) {
   // Get default value from map
   $ms-amount: map-get($illusion-ms-sizes, $amount);
   // Support for non default values

--- a/scss/tools/mixins/_property.scss
+++ b/scss/tools/mixins/_property.scss
@@ -1,6 +1,9 @@
 // Property
 
-@mixin property($property, $value) {
+@mixin property(
+  $property,
+  $value
+) {
   // Change properties to logical properties
   @if $illusion-logical-properties {
     @each $prop, $val in $illusion-logical-properties-map {

--- a/scss/tools/mixins/_pseudo.scss
+++ b/scss/tools/mixins/_pseudo.scss
@@ -1,6 +1,12 @@
 // Pseudo elements
 
-@mixin pseudo($illusion-pseudo: $illusion-pseudo, $parent-position: $illusion-pseudo-parent-position, $position: $illusion-pseudo-position, $content: $illusion-pseudo-content, $display: $illusion-pseudo-display) {
+@mixin pseudo(
+  $illusion-pseudo: $illusion-pseudo,
+  $parent-position: $illusion-pseudo-parent-position,
+  $position: $illusion-pseudo-position,
+  $content: $illusion-pseudo-content,
+  $display: $illusion-pseudo-display
+) {
   @if $parent-position != false {
     position: $parent-position;
   }

--- a/scss/tools/mixins/_ratio-block.scss
+++ b/scss/tools/mixins/_ratio-block.scss
@@ -1,6 +1,10 @@
 // Aspect ratio blocks
 
-@mixin ratio-block($ratio: $illusion-ratio-block, $overflow: $illusion-ratio-block-overflow, $after: $illusion-ratio-block-after) {
+@mixin ratio-block(
+  $ratio: $illusion-ratio-block,
+  $overflow: $illusion-ratio-block-overflow,
+  $after: $illusion-ratio-block-after
+) {
 
   // Get percentage
   $percent: calculateRatio($ratio);

--- a/scss/tools/mixins/_reset.scss
+++ b/scss/tools/mixins/_reset.scss
@@ -1,6 +1,12 @@
 // Reset elements
 
-@mixin reset($margin: $illusion-reset-margin, $padding: $illusion-reset-padding, $list-style: $illusion-reset-list-style, $border: $illusion-reset-border, $background: $illusion-reset-background) {
+@mixin reset(
+  $margin: $illusion-reset-margin,
+  $padding: $illusion-reset-padding,
+  $list-style: $illusion-reset-list-style,
+  $border: $illusion-reset-border,
+  $background: $illusion-reset-background
+) {
   @if $margin != false {
     @include property("margin", $margin);
   }

--- a/scss/tools/mixins/_row.scss
+++ b/scss/tools/mixins/_row.scss
@@ -1,6 +1,8 @@
 // Row
 
-@mixin row($type: $illusion-grid-row-type) {
+@mixin row(
+  $type: $illusion-grid-row-type
+) {
 
   // Floats
   @if $type != flex {

--- a/scss/tools/mixins/_selectors.scss
+++ b/scss/tools/mixins/_selectors.scss
@@ -1,6 +1,8 @@
 // Selectors
 
-@mixin selectors($selectors...) {
+@mixin selectors(
+  $selectors...
+) {
   @each $selector in $selectors {
     #{$selector} {
       @content;

--- a/scss/tools/mixins/_shift.scss
+++ b/scss/tools/mixins/_shift.scss
@@ -2,7 +2,13 @@
 
 @use "sass:math";
 
-@mixin shift($shift: $illusion-shift, $fromto: $illusion-shift-fromto, $multiplier: $illusion-shift-multiplier, $defaults: $illusion-shift-defaults, $gutter: $illusion-shift-gutter) {
+@mixin shift(
+  $shift: $illusion-shift,
+  $fromto: $illusion-shift-fromto,
+  $multiplier: $illusion-shift-multiplier,
+  $defaults: $illusion-shift-defaults,
+  $gutter: $illusion-shift-gutter
+) {
 
   // Give a warning when $multiplier is not dividable by 0.5
   @if ($multiplier % 0.5 != 0 and $illusion-display-warnings != false) {

--- a/scss/tools/mixins/_spacing.scss
+++ b/scss/tools/mixins/_spacing.scss
@@ -37,11 +37,19 @@
           @if ($minus % 2 != 0 and $illusion-display-warnings != false) { @warn '$minus should be an even number'; }
           $subtract: $minus * 0.5;
         }
-        #{$type}-top: $spacing - $subtract;
+        @if $illusion-logical-properties {
+          @include property("#{$type}-top", $spacing - $subtract);
+        } @else {
+          #{$type}-top: $spacing - $subtract;
+        }
 
         @if $lastchildnone != false {
           &:last-child {
-            #{$type}-top: 0;
+            @if $illusion-logical-properties {
+              @include property("#{$type}-top", 0);
+            } @else {
+              #{$type}-top: 0;
+            }
           }
         }
       }
@@ -52,11 +60,19 @@
           @if ($minus % 2 != 0 and $illusion-display-warnings != false) { @warn '$minus should be an even number'; }
           $subtract: $minus * 0.5;
         }
-        #{$type}-right: $spacing - $subtract;
+        @if $illusion-logical-properties {
+          @include property("#{$type}-right", $spacing - $subtract);
+        } @else {
+          #{$type}-right: $spacing - $subtract;
+        }
 
         @if $lastchildnone != false {
           &:last-child {
-            #{$type}-right: 0;
+            @if $illusion-logical-properties {
+              @include property("#{$type}-right", 0);
+            } @else {
+              #{$type}-right: 0;
+            }
           }
         }
       }
@@ -67,11 +83,19 @@
           @if ($minus % 2 != 0 and $illusion-display-warnings != false) { @warn '$minus should be an even number'; }
           $subtract: $minus * 0.5;
         }
-        #{$type}-bottom: $spacing - $subtract;
+        @if $illusion-logical-properties {
+          @include property("#{$type}-bottom", $spacing - $subtract);
+        } @else {
+          #{$type}-bottom: $spacing - $subtract;
+        }
 
         @if $lastchildnone != false {
           &:last-child {
-            #{$type}-bottom: 0;
+            @if $illusion-logical-properties {
+              @include property("#{$type}-bottom", 0);
+            } @else {
+              #{$type}-bottom: 0;
+            }
           }
         }
       }
@@ -82,11 +106,19 @@
           @if ($minus % 2 != 0 and $illusion-display-warnings != false) { @warn '$minus should be an even number'; }
           $subtract: $minus * 0.5;
         }
-        #{$type}-left: $spacing - $subtract;
+        @if $illusion-logical-properties {
+          @include property("#{$type}-left", $spacing - $subtract);
+        } @else {
+          #{$type}-left: $spacing - $subtract;
+        }
 
         @if $lastchildnone != false {
           &:last-child {
-            #{$type}-left: 0;
+            @if $illusion-logical-properties {
+              @include property("#{$type}-left", 0);
+            } @else {
+              #{$type}-left: 0;
+            }
           }
         }
       }

--- a/scss/tools/mixins/_spacing.scss
+++ b/scss/tools/mixins/_spacing.scss
@@ -2,7 +2,14 @@
 //
 // Responsive spacing that follows the grid breakpoints
 
-@mixin spacing($sides: $illusion-spacing-sides, $type: $illusion-spacing-type, $multiplier: $illusion-spacing-multiplier, $fromto: $illusion-spacing-fromto, $lastchildnone: $illusion-spacing-lastchildnone, $minus: $illusion-spacing-minus) {
+@mixin spacing(
+  $sides: $illusion-spacing-sides,
+  $type: $illusion-spacing-type,
+  $multiplier: $illusion-spacing-multiplier,
+  $fromto: $illusion-spacing-fromto,
+  $lastchildnone: $illusion-spacing-lastchildnone,
+  $minus: $illusion-spacing-minus
+) {
 
   // Give a warning when $multiplier is not dividable by 0.5
   @if ($multiplier % 0.5 != 0 and $illusion-display-warnings != false) {

--- a/scss/tools/mixins/_span.scss
+++ b/scss/tools/mixins/_span.scss
@@ -2,7 +2,17 @@
 
 @use "sass:math";
 
-@mixin span($span: $illusion-span-span, $fromto: $illusion-span-fromto, $multiplier: $illusion-span-multiplier, $bottom: $illusion-span-bottom, $defaults: $illusion-span-defaults, $omega: $illusion-span-omega, $gutter: $illusion-span-gutter, $includeWidth: $illusion-span-includeWidth, $includeMargin: $illusion-span-includeMargin) {
+@mixin span(
+  $span: $illusion-span-span,
+  $fromto: $illusion-span-fromto,
+  $multiplier: $illusion-span-multiplier,
+  $bottom: $illusion-span-bottom,
+  $defaults: $illusion-span-defaults,
+  $omega: $illusion-span-omega,
+  $gutter: $illusion-span-gutter,
+  $includeWidth: $illusion-span-includeWidth,
+  $includeMargin: $illusion-span-includeMargin
+) {
 
   // Give a warning when $multiplier is not dividable by 0.5
   @if ($multiplier % 0.5 != 0 and $illusion-display-warnings != false) {

--- a/scss/tools/mixins/_stack.scss
+++ b/scss/tools/mixins/_stack.scss
@@ -1,7 +1,9 @@
 // Stack
 // ==========================================================================
 
-@mixin stack($value: $illusion-stack-value) {
+@mixin stack(
+  $value: $illusion-stack-value
+) {
   & > * + * {
     @include property("margin-top", $value);
   }

--- a/scss/tools/mixins/_svg-background.scss
+++ b/scss/tools/mixins/_svg-background.scss
@@ -2,7 +2,17 @@
 //
 // @include svg-background('<g transform="matrix(2.18679,0,0,2.18679,5.43964,-0.0421697)"><path d="M5.9 5.3L0.5 0.1C0.4 0 0.2 0 0.1 0.1 0 0.2 0 0.4 0.1 0.5L5.2 5.5 0.1 10.5C0 10.6 0 10.8 0.1 10.9 0.2 11 0.2 11 0.3 11 0.4 11 0.5 11 0.5 10.9L5.9 5.7C6 5.6 6 5.4 5.9 5.3Z"/></g>', black, 16);
 
-@mixin svg-background($svg, $color: $illusion-svg-background-color, $width: $illusion-svg-background-width, $height: $illusion-svg-background-height, $viewboxWidth: $illusion-svg-background-viewboxWidth, $viewboxHeight: $illusion-svg-background-viewboxHeight, $background-position: $illusion-svg-background-position, $background-repeat: $illusion-svg-background-repeat, $unit: $illusion-svg-background-size-unit) {
+@mixin svg-background(
+  $svg,
+  $color: $illusion-svg-background-color,
+  $width: $illusion-svg-background-width,
+  $height: $illusion-svg-background-height,
+  $viewboxWidth: $illusion-svg-background-viewboxWidth,
+  $viewboxHeight: $illusion-svg-background-viewboxHeight,
+  $background-position: $illusion-svg-background-position,
+  $background-repeat: $illusion-svg-background-repeat,
+  $unit: $illusion-svg-background-size-unit
+) {
   @if $height == false {
     $height: $width;
   }

--- a/scss/tools/mixins/_transition.scss
+++ b/scss/tools/mixins/_transition.scss
@@ -5,7 +5,9 @@
 //
 // Pass in any number of transitions
 
-@mixin transition($transitions...) {
+@mixin transition(
+  $transitions...
+) {
   $unfoldedTransitions: ();
   @if length($transitions) == 0 {
     $unfoldedTransitions: append($unfoldedTransitions, unfoldTransition(all), comma);

--- a/scss/tools/mixins/_triangle.scss
+++ b/scss/tools/mixins/_triangle.scss
@@ -1,7 +1,11 @@
 // Triangle
 // CSS only triangles using borders
 
-@mixin triangle($direction: $illusion-triangle-direction, $size: $illusion-triangle-size, $color: $illusion-triangle-color) {
+@mixin triangle(
+  $direction: $illusion-triangle-direction,
+  $size: $illusion-triangle-size,
+  $color: $illusion-triangle-color
+) {
 
   // Top and bottom arrows
   @if $direction == top or $direction == bottom {

--- a/scss/tools/mixins/_visually-hidden.scss
+++ b/scss/tools/mixins/_visually-hidden.scss
@@ -1,6 +1,16 @@
 // Visually hidden
 
-@mixin visually-hidden($position: $illusion-visually-hidden-position, $overflow: $illusion-visually-hidden-overflow, $backface-visibility: $illusion-visually-hidden-backface-visibility, $clip: $illusion-visually-hidden-clip, $height: $illusion-visually-hidden-height, $width: $illusion-visually-hidden-width, $margin: $illusion-visually-hidden-margin, $padding: $illusion-visually-hidden-padding, $border: $illusion-visually-hidden-border) {
+@mixin visually-hidden(
+  $position: $illusion-visually-hidden-position,
+  $overflow: $illusion-visually-hidden-overflow,
+  $backface-visibility: $illusion-visually-hidden-backface-visibility,
+  $clip: $illusion-visually-hidden-clip,
+  $height: $illusion-visually-hidden-height,
+  $width: $illusion-visually-hidden-width,
+  $margin: $illusion-visually-hidden-margin,
+  $padding: $illusion-visually-hidden-padding,
+  $border: $illusion-visually-hidden-border
+) {
   @if $position != false {
     position: $position;
   }

--- a/scss/tools/mixins/_visually-shown.scss
+++ b/scss/tools/mixins/_visually-shown.scss
@@ -1,6 +1,16 @@
 // Visually shown
 
-@mixin visually-shown($position: $illusion-visually-shown-position, $overflow: $illusion-visually-shown-overflow, $backface-visibility: $illusion-visually-shown-backface-visibility, $clip: $illusion-visually-shown-clip, $height: $illusion-visually-shown-height, $width: $illusion-visually-shown-width, $margin: $illusion-visually-shown-margin, $padding: $illusion-visually-shown-padding, $border: $illusion-visually-shown-border) {
+@mixin visually-shown(
+  $position: $illusion-visually-shown-position,
+  $overflow: $illusion-visually-shown-overflow,
+  $backface-visibility: $illusion-visually-shown-backface-visibility,
+  $clip: $illusion-visually-shown-clip,
+  $height: $illusion-visually-shown-height,
+  $width: $illusion-visually-shown-width,
+  $margin: $illusion-visually-shown-margin,
+  $padding: $illusion-visually-shown-padding,
+  $border: $illusion-visually-shown-border
+) {
   @if $position != false {
     position: $position;
   }


### PR DESCRIPTION
This PR will adjust all mixins in the mixin directory. 
It will change the inline setup of all variables to separate rows for each variable.
This way it is easier to  read the variables of the mixins. 

# before
```
// Pseudo elements

@mixin pseudo($illusion-pseudo: $illusion-pseudo, $parent-position: $illusion-pseudo-parent-position, $position: $illusion-pseudo-position, $content: $illusion-pseudo-content, $display: $illusion-pseudo-display
) {
  @if $parent-position != false {
```

# after
```
// Pseudo elements

@mixin pseudo(
  $illusion-pseudo: $illusion-pseudo,
  $parent-position: $illusion-pseudo-parent-position,
  $position: $illusion-pseudo-position,
  $content: $illusion-pseudo-content,
  $display: $illusion-pseudo-display
) {
  @if $parent-position != false {
```
