### PR TITLE
add prefix variable to css-variables

### DIFF
--- a/scss/tools/_tools.scss
+++ b/scss/tools/_tools.scss
@@ -2,6 +2,7 @@
 @use "sass:math";
 
 $illusion-display-warnings: true !default;
+$illusion-css-variables-prefix: '' !default;
 
 // Map collect is being used by logical properties variables
 @import "functions/mapCollect";

--- a/scss/tools/mixins/_modular-scale.scss
+++ b/scss/tools/mixins/_modular-scale.scss
@@ -22,9 +22,9 @@
   // Logical properties?
   @if $illusion-logical-properties {
     @if ($subtractFrom) {
-      @include property("#{$property}", calc(#{$subtractFrom} - (var(--spacing) * #{$ms-amount})));
+      @include property("#{$property}", calc(#{$subtractFrom} - (var(--#{$illusion-css-variables-prefix}spacing) * #{$ms-amount})));
     } @else {
-      @include property("#{$property}", calc(var(--spacing) * #{$ms-amount}));
+      @include property("#{$property}", calc(var(--#{$illusion-css-variables-prefix}spacing) * #{$ms-amount}));
     }
   } @else {
     // Default
@@ -37,9 +37,9 @@
     @if ($illusion-fallback == false) {
       @supports (--css: variables) {
         @if ($subtractFrom) {
-          #{$property}: calc(#{$subtractFrom} - (var(--spacing) * #{$ms-amount}));
+          #{$property}: calc(#{$subtractFrom} - (var(--#{$illusion-css-variables-prefix}spacing) * #{$ms-amount}));
         } @else {
-          #{$property}: calc(var(--spacing) * #{$ms-amount});
+          #{$property}: calc(var(--#{$illusion-css-variables-prefix}spacing) * #{$ms-amount});
         }
       }
     }


### PR DESCRIPTION
This PR will add an empty prefix to be used inside css variables.
The variable `$illusion-css-variables-prefix` cloud and should be adjusted per project. 