### PR TITLE
Update _pseudo.scss

### DIFF
--- a/scss/tools/mixins/_pseudo.scss
+++ b/scss/tools/mixins/_pseudo.scss
@@ -10,7 +10,9 @@
   $display: pseudo.$illusion-pseudo-display
 ) {
   @if $parent-position != false {
-    position: $parent-position;
+    & {
+      position: $parent-position;
+    }
   }
 
   &::#{$illusion-pseudo} {


### PR DESCRIPTION
This PR will solve a **Sass deprecation warning** regarding **declarations that appear after nested rules**. In `@mixin pseudo()` in `_pseudo.scss`, you have this declaration:

```scss
@if $parent-position != false {
  position: $parent-position;
}
```

This declaration appears before your nested selector `&::#{$illusion-pseudo}`, and Sass is warning that this behavior will change in future versions.

The solution: Wrap the `position` declaration inside `& {}`

