### PR TITLE
use getContainer only instead of both getcontainer and getContainer

### DIFF
--- a/scss/tools/functions/_getContainer.scss
+++ b/scss/tools/functions/_getContainer.scss
@@ -5,7 +5,7 @@
 
 // Gets the container size and returns the default settings variable when it's not set
 
-@function getcontainer($span) {
+@function getContainer($span) {
   @if list.length($span) == 3 {
     $container: list.nth($span, 3);
     @return $container;

--- a/scss/tools/functions/_getWidth.scss
+++ b/scss/tools/functions/_getWidth.scss
@@ -3,7 +3,7 @@
 @use "sass:map";
 @use "sass:list";
 @use "smallestGutter";
-@use "getcontainer";
+@use "getContainer";
 @use "mapGetNext";
 @use "mapGet";
 @use "largestWidth";
@@ -33,7 +33,7 @@
 
   // Span values
   $spanColumns: list.nth($span, 1);
-  $spanContainer: getcontainer.getcontainer($span);
+  $spanContainer: getContainer.getContainer($span);
   $spanAmount: math.div($spanContainer, $spanColumns);
 
   // Run through each breakpoint and create a new map

--- a/scss/tools/mixins/_gallery.scss
+++ b/scss/tools/mixins/_gallery.scss
@@ -20,7 +20,7 @@
 
   // Span values
   $spanColumns: list.nth($span, 1);
-  $spanContainer: getContainer.getcontainer($span);
+  $spanContainer: getContainer.getContainer($span);
   $spanAmount: math.div($spanContainer, $spanColumns);
 
   // Span columns

--- a/scss/tools/mixins/_shift.scss
+++ b/scss/tools/mixins/_shift.scss
@@ -42,7 +42,7 @@
 
       // Shift values
       $spanColumns: list.nth($shift, 1);
-      $spanContainer: getContainer.getcontainer($shift);
+      $spanContainer: getContainer.getContainer($shift);
       $spanAmount: math.div($spanContainer, $spanColumns);
 
       // Negative

--- a/scss/tools/mixins/_span.scss
+++ b/scss/tools/mixins/_span.scss
@@ -46,7 +46,7 @@
 
       // Span values
       $spanColumns: list.nth($span, 1);
-      $spanContainer: getContainer.getcontainer($span);
+      $spanContainer: getContainer.getContainer($span);
       $spanAmount: math.div($spanContainer, $spanColumns);
 
       // Column values


### PR DESCRIPTION
This PR for Illusion will rename all `getcontainer` into `getContainer` making it more consistent throughout the project