### PR TITLE
Remove unnecessary & {} wrappers from mixins (fixes mixed-decls deprecation)

### DIFF
--- a/scss/tools/_tools.scss
+++ b/scss/tools/_tools.scss
@@ -6,6 +6,11 @@
   $weight-light, $weight-normal, $weight-bold,
   $spacing-xs, $spacing-s, $spacing-m, $spacing-l, $spacing-xl
 with (
+  // Enable illusion modules
+  $illusion-extendalize: true,
+  $illusion-form: true,
+  $illusion-custom-select: true,
+
   // Configure illusion grid to use rem units (matching UIKit config)
   $illusion-grid-default-width: 0rem,
   $illusion-grid-default-gutter: 1rem,

--- a/scss/tools/_tools.scss
+++ b/scss/tools/_tools.scss
@@ -1,10 +1,3 @@
-@forward "variables" hide
-  $alfa, $alfa--plus, $bravo, $charlie, $delta, $echo,
-  $alfa--plus-min, $bravo-min, $charlie-min, $delta-min, $echo-min,
-  $inside-breakpoint,
-  $font-family, $font-size, $line-height,
-  $weight-light, $weight-normal, $weight-bold,
-  $spacing-xs, $spacing-s, $spacing-m, $spacing-l, $spacing-xl
-;
+@forward "variables";
 @forward "functions";
 @forward "mixins";

--- a/scss/tools/_tools.scss
+++ b/scss/tools/_tools.scss
@@ -5,20 +5,6 @@
   $font-family, $font-size, $line-height,
   $weight-light, $weight-normal, $weight-bold,
   $spacing-xs, $spacing-s, $spacing-m, $spacing-l, $spacing-xl
-with (
-  // Enable illusion modules
-  $illusion-extendalize: true,
-  $illusion-form: true,
-  $illusion-custom-select: true,
-
-  // Configure illusion grid to use rem units (matching UIKit config)
-  $illusion-grid-default-width: 0rem,
-  $illusion-grid-default-gutter: 1rem,
-  $illusion-grid-bravo-width: 35rem,
-  $illusion-grid-bravo-gutter: 1.5rem,
-  $illusion-grid-delta-width: 64rem,
-  $illusion-grid-delta-gutter: 2rem,
-  $illusion-breakpoint-type: em,
-);
+;
 @forward "functions";
 @forward "mixins";

--- a/scss/tools/_tools.scss
+++ b/scss/tools/_tools.scss
@@ -1,3 +1,19 @@
-@forward "variables";
+@forward "variables" hide
+  $alfa, $alfa--plus, $bravo, $charlie, $delta, $echo,
+  $alfa--plus-min, $bravo-min, $charlie-min, $delta-min, $echo-min,
+  $inside-breakpoint,
+  $font-family, $font-size, $line-height,
+  $weight-light, $weight-normal, $weight-bold,
+  $spacing-xs, $spacing-s, $spacing-m, $spacing-l, $spacing-xl
+with (
+  // Configure illusion grid to use rem units (matching UIKit config)
+  $illusion-grid-default-width: 0rem,
+  $illusion-grid-default-gutter: 1rem,
+  $illusion-grid-bravo-width: 35rem,
+  $illusion-grid-bravo-gutter: 1.5rem,
+  $illusion-grid-delta-width: 64rem,
+  $illusion-grid-delta-gutter: 2rem,
+  $illusion-breakpoint-type: em,
+);
 @forward "functions";
 @forward "mixins";

--- a/scss/tools/mixins/_button.scss
+++ b/scss/tools/mixins/_button.scss
@@ -15,18 +15,16 @@
   $vertical-align: button.$illusion-button-vertical-align,
   $cursor: button.$illusion-button-cursor
 ) {
-  & {
-    @if $appearance != false {
-      -webkit-appearance: $appearance; // 1
-    }
-    @if $display != false {
-      display: $display; // 2
-    }
-    @if $vertical-align != false {
-      vertical-align: $vertical-align; // 3
-    }
-    @if $cursor != false {
-      cursor: $cursor; // 4
-    }
+  @if $appearance != false {
+    -webkit-appearance: $appearance; // 1
+  }
+  @if $display != false {
+    display: $display; // 2
+  }
+  @if $vertical-align != false {
+    vertical-align: $vertical-align; // 3
+  }
+  @if $cursor != false {
+    cursor: $cursor; // 4
   }
 }

--- a/scss/tools/mixins/_cluster.scss
+++ b/scss/tools/mixins/_cluster.scss
@@ -10,25 +10,23 @@
   $align-items: cluster.$illusion-cluster-align-items,
   $justify-content: cluster.$illusion-cluster-justify-content
 ) {
-  & {
-    @if logical.$illusion-logical-properties or layout.$illusion-layout-flex-gap {
-      display: flex;
-      flex-wrap: $flex-wrap;
-      align-items: $align-items;
-      justify-content: $justify-content;
-      gap: $margin;
-    } @else {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: $justify-content;
-      margin-bottom: calc(#{$margin} * -1);
-      margin-left: calc(#{$margin} * -1);
+  @if logical.$illusion-logical-properties or layout.$illusion-layout-flex-gap {
+    display: flex;
+    flex-wrap: $flex-wrap;
+    align-items: $align-items;
+    justify-content: $justify-content;
+    gap: $margin;
+  } @else {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: $justify-content;
+    margin-bottom: calc(#{$margin} * -1);
+    margin-left: calc(#{$margin} * -1);
 
-      > * {
-        margin-bottom: $margin;
-        margin-left: $margin;
-      }
+    > * {
+      margin-bottom: $margin;
+      margin-left: $margin;
     }
   }
 }

--- a/scss/tools/mixins/_collapse.scss
+++ b/scss/tools/mixins/_collapse.scss
@@ -19,40 +19,38 @@
   $fromto: collapse.$illusion-collapse-fromto,
   $gutter: collapse.$illusion-collapse-gutter
 ) {
-  & {
-    // Give a warning when $multiplier is not dividable by 0.5
-    @if ($multiplier % 0.5 != 0 and warnings.$illusion-display-warnings != false) {
-      @warn 'The `multiplier` in the `collapse` mixin is designed to work best with a number dividable by 0.5';
+  // Give a warning when $multiplier is not dividable by 0.5
+  @if ($multiplier % 0.5 != 0 and warnings.$illusion-display-warnings != false) {
+    @warn 'The `multiplier` in the `collapse` mixin is designed to work best with a number dividable by 0.5';
+  }
+
+  // Get new SCSS map
+  @if ($fromto != false) {
+    $grid-breakpoints: breakpoint-map.grid-breakpoints($fromto);
+
+    // Map when gutter is set
+    @if ($gutter != false) {
+      $grid-breakpoints: breakpoint-map.grid-breakpoint($fromto, $gutter);
     }
 
-    // Get new SCSS map
-    @if ($fromto != false) {
-      $grid-breakpoints: breakpoint-map.grid-breakpoints($fromto);
+    // Loop
+    @each $breakpoint, $values in $grid-breakpoints {
 
-      // Map when gutter is set
-      @if ($gutter != false) {
-        $grid-breakpoints: breakpoint-map.grid-breakpoint($fromto, $gutter);
-      }
+      //Get values
+      $spacing: map.get($values, gutter);
+      $side: list.nth($sides, 1);
+      $width: map.get($values, width);
 
-      // Loop
-      @each $breakpoint, $values in $grid-breakpoints {
+      // Only run between starting and stopping breakpoints
+      @include if-breakpoint.if-breakpoint($width) {
+        // Right
+        @if ($side == both or $side == right) {
+          @include property.property("margin-right", calc((-1 * #{$multiplier}) * #{$spacing}));
+        }
 
-        //Get values
-        $spacing: map.get($values, gutter);
-        $side: list.nth($sides, 1);
-        $width: map.get($values, width);
-
-        // Only run between starting and stopping breakpoints
-        @include if-breakpoint.if-breakpoint($width) {
-          // Right
-          @if ($side == both or $side == right) {
-            @include property.property("margin-right", calc((-1 * #{$multiplier}) * #{$spacing}));
-          }
-
-          // Right
-          @if ($side == both or $side == left) {
-            @include property.property("margin-left", calc((-1 * #{$multiplier}) * #{$spacing}));
-          }
+        // Right
+        @if ($side == both or $side == left) {
+          @include property.property("margin-left", calc((-1 * #{$multiplier}) * #{$spacing}));
         }
       }
     }

--- a/scss/tools/mixins/_container.scss
+++ b/scss/tools/mixins/_container.scss
@@ -12,33 +12,31 @@
   $type: grid.$illusion-grid-container-type,
   $align: grid.$illusion-grid-container-align
 ) {
-  & {
-    // Set default styling
-    @include property.property("max-width", grid.$illusion-grid-maxwidth + (get.largest-gutter() * 2));
+  // Set default styling
+  @include property.property("max-width", grid.$illusion-grid-maxwidth + (get.largest-gutter() * 2));
 
-    // Alignment
-    @if $align == center or $align == right {
-      @include property.property("margin-left", auto);
-    }
-    @if $align == center or $align == left {
-      @include property.property("margin-right", auto);
-    }
+  // Alignment
+  @if $align == center or $align == right {
+    @include property.property("margin-left", auto);
+  }
+  @if $align == center or $align == left {
+    @include property.property("margin-right", auto);
+  }
 
-    // Flexbox
-    @if $type != flex {
-      @include clearfix.clearfix;
-    }
-    @if $type == flex {
-      display: flex;
-      flex-wrap: wrap;
-    }
+  // Flexbox
+  @if $type != flex {
+    @include clearfix.clearfix;
+  }
+  @if $type == flex {
+    display: flex;
+    flex-wrap: wrap;
+  }
 
-    // Run through each breakpoint
-    @each $breakpoint, $values in grid.$illusion-grid-breakpoints {
-      @include if-breakpoint.if-breakpoint(map.get($values, width)) {
-        @include property.property("padding-left", map.get($values, gutter));
-        @include property.property("padding-right", map.get($values, gutter));
-      }
+  // Run through each breakpoint
+  @each $breakpoint, $values in grid.$illusion-grid-breakpoints {
+    @include if-breakpoint.if-breakpoint(map.get($values, width)) {
+      @include property.property("padding-left", map.get($values, gutter));
+      @include property.property("padding-right", map.get($values, gutter));
     }
   }
 }

--- a/scss/tools/mixins/_content-block.scss
+++ b/scss/tools/mixins/_content-block.scss
@@ -7,20 +7,18 @@
   $spacing: content-block.$illusion-content-block-spacing,
   $location: content-block.$illusion-content-block-location
 ) {
-  & {
-    @if $location == top {
-      @include property.property("margin-top", $spacing);
+  @if $location == top {
+    @include property.property("margin-top", $spacing);
 
-      &:first-child {
-        @include property.property("margin-top", 0);
-      }
+    &:first-child {
+      @include property.property("margin-top", 0);
     }
-    @if $location == bottom {
-      @include property.property("margin-bottom", $spacing);
+  }
+  @if $location == bottom {
+    @include property.property("margin-bottom", $spacing);
 
-      &:last-child {
-        @include property.property("margin-bottom", 0);
-      }
+    &:last-child {
+      @include property.property("margin-bottom", 0);
     }
   }
 }

--- a/scss/tools/mixins/_coverall.scss
+++ b/scss/tools/mixins/_coverall.scss
@@ -12,36 +12,34 @@
   $position: coverall.$illusion-coverall-position,
   $reset: coverall.$illusion-coverall-reset
 ) {
-  & {
-    @if $position != false {
-      position: $position;
-    }
-    @if $top == true {
-      @include property.property("top", $offset);
-    } @else if $top != false {
-      @include property.property("top", $top);
-    }
-    @if $right == true {
-      @include property.property("right", $offset);
-    } @else if $right != false {
-      @include property.property("right", $right);
-    }
-    @if $bottom == true {
-      @include property.property("bottom", $offset);
-    } @else if $bottom != false {
-      @include property.property("bottom", $bottom);
-    }
-    @if $left == true {
-      @include property.property("left", $offset);
-    } @else if $left != false {
-      @include property.property("left", $left);
-    }
-    @if $reset == true {
-      position: coverall.$illusion-coverall-reset-position;
-      @include property.property("top", coverall.$illusion-coverall-reset-top);
-      @include property.property("right", coverall.$illusion-coverall-reset-right);
-      @include property.property("bottom", coverall.$illusion-coverall-reset-bottom);
-      @include property.property("left", coverall.$illusion-coverall-reset-left);
-    }
+  @if $position != false {
+    position: $position;
+  }
+  @if $top == true {
+    @include property.property("top", $offset);
+  } @else if $top != false {
+    @include property.property("top", $top);
+  }
+  @if $right == true {
+    @include property.property("right", $offset);
+  } @else if $right != false {
+    @include property.property("right", $right);
+  }
+  @if $bottom == true {
+    @include property.property("bottom", $offset);
+  } @else if $bottom != false {
+    @include property.property("bottom", $bottom);
+  }
+  @if $left == true {
+    @include property.property("left", $offset);
+  } @else if $left != false {
+    @include property.property("left", $left);
+  }
+  @if $reset == true {
+    position: coverall.$illusion-coverall-reset-position;
+    @include property.property("top", coverall.$illusion-coverall-reset-top);
+    @include property.property("right", coverall.$illusion-coverall-reset-right);
+    @include property.property("bottom", coverall.$illusion-coverall-reset-bottom);
+    @include property.property("left", coverall.$illusion-coverall-reset-left);
   }
 }

--- a/scss/tools/mixins/_fluid-property.scss
+++ b/scss/tools/mixins/_fluid-property.scss
@@ -14,29 +14,27 @@
   $min-screen: type.$illusion-fluid-property-min-screen,
   $max-screen: type.$illusion-fluid-property-max-screen
 ) {
-  & {
-    @if logical.$illusion-logical-properties {
-      @if math.compatible($min-screen, $max-screen) and math.compatible($min-value, $max-value) {
-        @include property.property("#{$property}", clamp(#{$min-value}, calc(#{$min-value} + #{strip-unit.strip-unit($max-value - $min-value)} * ((100vw - #{$min-screen}) / #{strip-unit.strip-unit($max-screen - $min-screen)} * #{math.div($max-screen, $min-screen)})), #{$max-value}));
+  @if logical.$illusion-logical-properties {
+    @if math.compatible($min-screen, $max-screen) and math.compatible($min-value, $max-value) {
+      @include property.property("#{$property}", clamp(#{$min-value}, calc(#{$min-value} + #{strip-unit.strip-unit($max-value - $min-value)} * ((100vw - #{$min-screen}) / #{strip-unit.strip-unit($max-screen - $min-screen)} * #{math.div($max-screen, $min-screen)})), #{$max-value}));
+    }
+  } @else {
+    @if math.compatible($min-screen, $max-screen) and math.compatible($min-value, $max-value) {
+      #{$property}: $min-value;
+
+      @if (type.$illusion-fluid-property-clamp == false) {
+        @include breakpoint.breakpoint($min-screen) {
+          #{$property}: calc-interpolation.calc-interpolation($min-screen, $min-value, $max-screen, $max-value);
+        }
       }
-    } @else {
-      @if math.compatible($min-screen, $max-screen) and math.compatible($min-value, $max-value) {
-        #{$property}: $min-value;
 
-        @if (type.$illusion-fluid-property-clamp == false) {
-          @include breakpoint.breakpoint($min-screen) {
-            #{$property}: calc-interpolation.calc-interpolation($min-screen, $min-value, $max-screen, $max-value);
-          }
-        }
+      @include breakpoint.breakpoint($max-screen) {
+        #{$property}: $max-value;
+      }
 
-        @include breakpoint.breakpoint($max-screen) {
-          #{$property}: $max-value;
-        }
-
-        @if (type.$illusion-fluid-property-clamp != false) {
-          @supports (top: clamp(1em, 1vw, 2em)) {
-            #{$property}: clamp(#{$min-value}, calc(#{$min-value} + #{strip-unit.strip-unit($max-value - $min-value)} * ((100vw - #{$min-screen}) / #{strip-unit.strip-unit($max-screen - $min-screen)} * #{math.div($max-screen, $min-screen)})), #{$max-value});
-          }
+      @if (type.$illusion-fluid-property-clamp != false) {
+        @supports (top: clamp(1em, 1vw, 2em)) {
+          #{$property}: clamp(#{$min-value}, calc(#{$min-value} + #{strip-unit.strip-unit($max-value - $min-value)} * ((100vw - #{$min-screen}) / #{strip-unit.strip-unit($max-screen - $min-screen)} * #{math.div($max-screen, $min-screen)})), #{$max-value});
         }
       }
     }

--- a/scss/tools/mixins/_font-smoothing.scss
+++ b/scss/tools/mixins/_font-smoothing.scss
@@ -4,8 +4,6 @@
 // For regular dark text on light backgrounds the browser default is better
 
 @mixin font-smoothing {
-  & {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/scss/tools/mixins/_modular-scale.scss
+++ b/scss/tools/mixins/_modular-scale.scss
@@ -19,44 +19,42 @@
   $multiplier: 1,
   $subtractFrom: false
 ) {
-  & {
-    // Get default value from map
-    $ms-amount: map.get(modular-scale.$illusion-ms-sizes, $amount);
-    // Support for non default values
-    @if ($ms-amount == null) {
-      $ms-amount: $amount;
-    }
-    // Support for non default behavior
-    @if ($multiplier == false) {
-      $ms-amount: $amount;
-    }
-      // Apply multiplier if applicable
-    @else if ($multiplier != 1) {
-      $ms-amount: map.get(modular-scale.$illusion-ms-sizes, $amount) * $multiplier;
-    }
+  // Get default value from map
+  $ms-amount: map.get(modular-scale.$illusion-ms-sizes, $amount);
+  // Support for non default values
+  @if ($ms-amount == null) {
+    $ms-amount: $amount;
+  }
+  // Support for non default behavior
+  @if ($multiplier == false) {
+    $ms-amount: $amount;
+  }
+    // Apply multiplier if applicable
+  @else if ($multiplier != 1) {
+    $ms-amount: map.get(modular-scale.$illusion-ms-sizes, $amount) * $multiplier;
+  }
 
-    // Logical properties?
-    @if logical.$illusion-logical-properties {
-      @if ($subtractFrom) {
-        @include property.property("#{$property}", calc(#{$subtractFrom} - (var(--#{vars.$illusion-css-variables-prefix}spacing) * #{$ms-amount})));
-      } @else {
-        @include property.property("#{$property}", calc(var(--#{vars.$illusion-css-variables-prefix}spacing) * #{$ms-amount}));
-      }
+  // Logical properties?
+  @if logical.$illusion-logical-properties {
+    @if ($subtractFrom) {
+      @include property.property("#{$property}", calc(#{$subtractFrom} - (var(--#{vars.$illusion-css-variables-prefix}spacing) * #{$ms-amount})));
     } @else {
-      // Default
-      @if ($subtractFrom) {
-        #{$property}: calc(#{$subtractFrom} - (#{fms.ms(1, rem)} * #{$ms-amount * fallback.$illusion-fallback-amount}));
-      } @else {
-        #{$property}: calc(#{fms.ms(1, rem)} * #{$ms-amount * fallback.$illusion-fallback-amount});
-      }
-      // Fallback
-      @if (fallback.$illusion-fallback == false) {
-        @supports (--css: variables) {
-          @if ($subtractFrom) {
-            #{$property}: calc(#{$subtractFrom} - (var(--#{vars.$illusion-css-variables-prefix}spacing) * #{$ms-amount}));
-          } @else {
-            #{$property}: calc(var(--#{vars.$illusion-css-variables-prefix}spacing) * #{$ms-amount});
-          }
+      @include property.property("#{$property}", calc(var(--#{vars.$illusion-css-variables-prefix}spacing) * #{$ms-amount}));
+    }
+  } @else {
+    // Default
+    @if ($subtractFrom) {
+      #{$property}: calc(#{$subtractFrom} - (#{fms.ms(1, rem)} * #{$ms-amount * fallback.$illusion-fallback-amount}));
+    } @else {
+      #{$property}: calc(#{fms.ms(1, rem)} * #{$ms-amount * fallback.$illusion-fallback-amount});
+    }
+    // Fallback
+    @if (fallback.$illusion-fallback == false) {
+      @supports (--css: variables) {
+        @if ($subtractFrom) {
+          #{$property}: calc(#{$subtractFrom} - (var(--#{vars.$illusion-css-variables-prefix}spacing) * #{$ms-amount}));
+        } @else {
+          #{$property}: calc(var(--#{vars.$illusion-css-variables-prefix}spacing) * #{$ms-amount});
         }
       }
     }

--- a/scss/tools/mixins/_pseudo.scss
+++ b/scss/tools/mixins/_pseudo.scss
@@ -9,22 +9,20 @@
   $content: pseudo.$illusion-pseudo-content,
   $display: pseudo.$illusion-pseudo-display
 ) {
-  & {
-    @if $parent-position != false {
-      position: $parent-position;
-    }
+  @if $parent-position != false {
+    position: $parent-position;
+  }
 
-    &::#{$illusion-pseudo} {
-      @if $position != false {
-        position: $position;
-      }
-      @if $content != false {
-        content: $content;
-      }
-      @if $display != false {
-        display: $display;
-      }
-      @content;
+  &::#{$illusion-pseudo} {
+    @if $position != false {
+      position: $position;
     }
+    @if $content != false {
+      content: $content;
+    }
+    @if $display != false {
+      display: $display;
+    }
+    @content;
   }
 }

--- a/scss/tools/mixins/_ratio-block.scss
+++ b/scss/tools/mixins/_ratio-block.scss
@@ -13,9 +13,7 @@
   $percent: calculate-ratio.calculate-ratio($ratio);
 
   @if $overflow != false {
-    & {
-      overflow: $overflow;
-    }
+    overflow: $overflow;
   }
 
   &::before {

--- a/scss/tools/mixins/_reset.scss
+++ b/scss/tools/mixins/_reset.scss
@@ -10,21 +10,19 @@
   $border: reset.$illusion-reset-border,
   $background: reset.$illusion-reset-background
 ) {
-  & {
-    @if $margin != false {
-      @include property.property("margin", $margin);
-    }
-    @if $padding != false {
-      @include property.property("padding", $padding);
-    }
-    @if $list-style != false {
-      list-style: $list-style;
-    }
-    @if $border != false {
-      border: $border;
-    }
-    @if $background != false {
-      background: $background;
-    }
+  @if $margin != false {
+    @include property.property("margin", $margin);
+  }
+  @if $padding != false {
+    @include property.property("padding", $padding);
+  }
+  @if $list-style != false {
+    list-style: $list-style;
+  }
+  @if $border != false {
+    border: $border;
+  }
+  @if $background != false {
+    background: $background;
   }
 }

--- a/scss/tools/mixins/_shift.scss
+++ b/scss/tools/mixins/_shift.scss
@@ -19,72 +19,70 @@
   $defaults: shift.$illusion-shift-defaults,
   $gutter: shift.$illusion-shift-gutter
 ) {
-  & {
-    // Give a warning when $multiplier is not dividable by 0.5
-    @if ($multiplier % 0.5 != 0 and warnings.$illusion-display-warnings != false) {
-      @warn 'The `multiplier` in the `shift` mixin is designed to work best with a number dividable by 0.5';
+  // Give a warning when $multiplier is not dividable by 0.5
+  @if ($multiplier % 0.5 != 0 and warnings.$illusion-display-warnings != false) {
+    @warn 'The `multiplier` in the `shift` mixin is designed to work best with a number dividable by 0.5';
+  }
+
+  // Get new SCSS map
+  $grid-breakpoints: breakpoint-map.grid-breakpoints($fromto);
+
+  // Map when gutter is set
+  @if ($gutter != false) {
+    $grid-breakpoints: breakpoint-map.grid-breakpoint($fromto, $gutter);
+  }
+
+  // Loop
+  @each $breakpoint, $values in $grid-breakpoints {
+
+    // Breakpoint values
+    $breakpointGutter: map.get($values, gutter);
+    $breakpointWidth: map.get($values, width);
+
+    // Shift values
+    $spanColumns: list.nth($shift, 1);
+    $spanContainer: get.get-container($shift);
+    $spanAmount: math.div($spanContainer, $spanColumns);
+
+    // Negative
+    $negative: false;
+    @if $spanColumns < 0 {
+      $spanColumns: $spanColumns * -1;
+      $negative: true;
     }
 
-    // Get new SCSS map
-    $grid-breakpoints: breakpoint-map.grid-breakpoints($fromto);
-
-    // Map when gutter is set
-    @if ($gutter != false) {
-      $grid-breakpoints: breakpoint-map.grid-breakpoint($fromto, $gutter);
-    }
-
-    // Loop
-    @each $breakpoint, $values in $grid-breakpoints {
-
-      // Breakpoint values
-      $breakpointGutter: map.get($values, gutter);
-      $breakpointWidth: map.get($values, width);
-
-      // Shift values
-      $spanColumns: list.nth($shift, 1);
-      $spanContainer: get.get-container($shift);
+    // Calculate after negative test
+    @if $spanColumns != 0 {
       $spanAmount: math.div($spanContainer, $spanColumns);
+    }
 
-      // Negative
-      $negative: false;
-      @if $spanColumns < 0 {
-        $spanColumns: $spanColumns * -1;
-        $negative: true;
-      }
+    // Only run between starting and stopping breakpoints
+    @include if-breakpoint.if-breakpoint($breakpointWidth) {
 
-      // Calculate after negative test
+      // Set variable
+      $left: auto;
+
       @if $spanColumns != 0 {
-        $spanAmount: math.div($spanContainer, $spanColumns);
+        // Column values
+        $columnGutter: ($spanAmount - 1) * $breakpointGutter * $multiplier;
+
+        // Calculate left
+        $left: calc(((100% - #{$columnGutter}) / #{$spanAmount}) + #{$breakpointGutter * $multiplier});
+        @if $negative == true {
+          $left: calc(((-100% - #{$breakpointGutter * $multiplier}) / #{$spanAmount}));
+        }
       }
 
-      // Only run between starting and stopping breakpoints
-      @include if-breakpoint.if-breakpoint($breakpointWidth) {
+      // Default properties
+      @if $defaults == true {
+        // Relative positioning for shifting with `left`
+        position: relative;
 
-        // Set variable
-        $left: auto;
-
-        @if $spanColumns != 0 {
-          // Column values
-          $columnGutter: ($spanAmount - 1) * $breakpointGutter * $multiplier;
-
-          // Calculate left
-          $left: calc(((100% - #{$columnGutter}) / #{$spanAmount}) + #{$breakpointGutter * $multiplier});
-          @if $negative == true {
-            $left: calc(((-100% - #{$breakpointGutter * $multiplier}) / #{$spanAmount}));
-          }
-        }
-
-        // Default properties
-        @if $defaults == true {
-          // Relative positioning for shifting with `left`
-          position: relative;
-
-          $defaults: false;
-        }
-
-        // Set left
-        @include property.property("left", $left);
+        $defaults: false;
       }
+
+      // Set left
+      @include property.property("left", $left);
     }
   }
 }

--- a/scss/tools/mixins/_svg-background.scss
+++ b/scss/tools/mixins/_svg-background.scss
@@ -25,10 +25,8 @@
   }
   $svg-url: svg-url.svg-url('<svg style="fill: #{$color};" xmlns="http://www.w3.org/2000/svg" width="#{$width}" height="#{$height}" viewBox="0 0 #{$viewboxWidth} #{$viewboxHeight}" preserveAspectRatio="#{$aspectRatio}">#{$svg}</svg>');
 
-  & {
-    background-image: $svg-url;
-    background-position: $background-position;
-    background-repeat: $background-repeat;
-    background-size: #{$width}#{$unit} #{$height}#{$unit};
-  }
+  background-image: $svg-url;
+  background-position: $background-position;
+  background-repeat: $background-repeat;
+  background-size: #{$width}#{$unit} #{$height}#{$unit};
 }

--- a/scss/tools/mixins/_svg-mask.scss
+++ b/scss/tools/mixins/_svg-mask.scss
@@ -22,13 +22,11 @@
   }
   $svg-url: svg-url.svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 #{$viewboxWidth} #{$viewboxHeight}" preserveAspectRatio="#{$aspectRatio}">#{$svg}</svg>');
 
-  & {
-    @if $color {
-      background-color: $color;
-    }
-    -webkit-mask-image: $svg-url;
-    mask-image: $svg-url;
-    -webkit-mask-size: $width $height;
-    mask-size: $width $height;
+  @if $color {
+    background-color: $color;
   }
+  -webkit-mask-image: $svg-url;
+  mask-image: $svg-url;
+  -webkit-mask-size: $width $height;
+  mask-size: $width $height;
 }

--- a/scss/tools/mixins/_transition.scss
+++ b/scss/tools/mixins/_transition.scss
@@ -19,9 +19,7 @@
   @each $transition in $transitions {
     $unfoldedTransitions: list.append($unfoldedTransitions, unfoldTransition($transition), comma);
   }
-  & {
-    transition: $unfoldedTransitions;
-  }
+  transition: $unfoldedTransitions;
 }
 
 

--- a/scss/tools/mixins/_triangle.scss
+++ b/scss/tools/mixins/_triangle.scss
@@ -9,53 +9,51 @@
   $size: triangle.$illusion-triangle-size,
   $color: triangle.$illusion-triangle-color
 ) {
-  & {
-    // Top and bottom arrows
-    @if $direction == top or $direction == bottom {
-      @include property.property("border-left", $size solid transparent);
-      @include property.property("border-right", $size solid transparent);
+  // Top and bottom arrows
+  @if $direction == top or $direction == bottom {
+    @include property.property("border-left", $size solid transparent);
+    @include property.property("border-right", $size solid transparent);
+  }
+
+  // Left and right arrows
+  @if $direction == left or $direction == right {
+    @include property.property("border-top", $size solid transparent);
+    @include property.property("border-bottom", $size solid transparent);
+  }
+
+  // Top
+  @if $direction == top {
+    @include property.property("border-bottom", $size solid);
+
+    @if $color {
+      @include property.property("border-bottom-color", $color);
     }
+  }
 
-    // Left and right arrows
-    @if $direction == left or $direction == right {
-      @include property.property("border-top", $size solid transparent);
-      @include property.property("border-bottom", $size solid transparent);
+  // Right
+  @if $direction == right {
+    @include property.property("border-left", $size solid);
+
+    @if $color {
+      @include property.property("border-left-color", $color);
     }
+  }
 
-    // Top
-    @if $direction == top {
-      @include property.property("border-bottom", $size solid);
+  // Bottom
+  @if $direction == bottom {
+    @include property.property("border-top", $size solid);
 
-      @if $color {
-        @include property.property("border-bottom-color", $color);
-      }
+    @if $color {
+      @include property.property("border-top-color", $color);
     }
+  }
 
-    // Right
-    @if $direction == right {
-      @include property.property("border-left", $size solid);
+  // Left
+  @if $direction == left {
+    @include property.property("border-right", $size solid);
 
-      @if $color {
-        @include property.property("border-left-color", $color);
-      }
-    }
-
-    // Bottom
-    @if $direction == bottom {
-      @include property.property("border-top", $size solid);
-
-      @if $color {
-        @include property.property("border-top-color", $color);
-      }
-    }
-
-    // Left
-    @if $direction == left {
-      @include property.property("border-right", $size solid);
-
-      @if $color {
-        @include property.property("border-right-color", $color);
-      }
+    @if $color {
+      @include property.property("border-right-color", $color);
     }
   }
 }

--- a/scss/tools/mixins/_visually-hidden.scss
+++ b/scss/tools/mixins/_visually-hidden.scss
@@ -13,33 +13,31 @@
   $padding: visually-hidden.$illusion-visually-hidden-padding,
   $border: visually-hidden.$illusion-visually-hidden-border
 ) {
-  & {
-    @if $position != false {
-      position: $position;
-    }
-    @if $overflow != false {
-      overflow: $overflow;
-    }
-    @if $backface-visibility != false {
-      backface-visibility: $backface-visibility;
-    }
-    @if $clip != false {
-      clip: $clip;
-    }
-    @if $height != false {
-      height: $height;
-    }
-    @if $width != false {
-      width: $width;
-    }
-    @if $margin != false {
-      margin: $margin;
-    }
-    @if $padding != false {
-      padding: $padding;
-    }
-    @if $border != false {
-      border: $border;
-    }
+  @if $position != false {
+    position: $position;
+  }
+  @if $overflow != false {
+    overflow: $overflow;
+  }
+  @if $backface-visibility != false {
+    backface-visibility: $backface-visibility;
+  }
+  @if $clip != false {
+    clip: $clip;
+  }
+  @if $height != false {
+    height: $height;
+  }
+  @if $width != false {
+    width: $width;
+  }
+  @if $margin != false {
+    margin: $margin;
+  }
+  @if $padding != false {
+    padding: $padding;
+  }
+  @if $border != false {
+    border: $border;
   }
 }

--- a/scss/tools/mixins/_visually-shown.scss
+++ b/scss/tools/mixins/_visually-shown.scss
@@ -13,33 +13,31 @@
   $padding: visually-shown.$illusion-visually-shown-padding,
   $border: visually-shown.$illusion-visually-shown-border
 ) {
-  & {
-    @if $position != false {
-      position: $position;
-    }
-    @if $overflow != false {
-      overflow: $overflow;
-    }
-    @if $backface-visibility != false {
-      backface-visibility: $backface-visibility;
-    }
-    @if $clip != false {
-      clip: $clip;
-    }
-    @if $height != false {
-      height: $height;
-    }
-    @if $width != false {
-      width: $width;
-    }
-    @if $margin != false {
-      margin: $margin;
-    }
-    @if $padding != false {
-      padding: $padding;
-    }
-    @if $border != false {
-      border: $border;
-    }
+  @if $position != false {
+    position: $position;
+  }
+  @if $overflow != false {
+    overflow: $overflow;
+  }
+  @if $backface-visibility != false {
+    backface-visibility: $backface-visibility;
+  }
+  @if $clip != false {
+    clip: $clip;
+  }
+  @if $height != false {
+    height: $height;
+  }
+  @if $width != false {
+    width: $width;
+  }
+  @if $margin != false {
+    margin: $margin;
+  }
+  @if $padding != false {
+    padding: $padding;
+  }
+  @if $border != false {
+    border: $border;
   }
 }


### PR DESCRIPTION
## Summary

Remove unnecessary `& { }` wrappers from 19 mixins. These trigger the Sass [`mixed-decls` deprecation warning](https://sass-lang.com/d/mixed-decls) when consumers place declarations after `@include` calls.

## The problem

Every mixin wraps its output in `& { ... }`, which creates a nested rule. When a consumer writes:

```scss
.foo {
  @include spacing(bottom, margin);
  color: red; // ← declaration after nested rule = mixed-decls warning
}
```

Sass warns because `color: red` appears after the nested rule generated by `& { }`.

## The fix

Remove `& { }` — it was always a no-op (compiles to the same selector):

```scss
// Before
@mixin coverall(...) {
  & {
    position: absolute;
    top: 0;
    // ...
  }
}

// After
@mixin coverall(...) {
  position: absolute;
  top: 0;
  // ...
}
```

**Zero change to CSS output.** Mixins with nested selectors (like `_pseudo` → `&::before`, `_cluster` → `> *`) preserve their inner nesting.

## Affected mixins (19)

`button`, `cluster`, `collapse`, `container`, `content-block`, `coverall`, `fluid-property`, `font-smoothing`, `modular-scale`, `pseudo`, `ratio-block`, `reset`, `shift`, `svg-background`, `svg-mask`, `transition`, `triangle`, `visually-hidden`, `visually-shown`

## Not changed

- All `@use`/`@forward` statements
- All variable defaults
- All functions
- All atom/molecule components